### PR TITLE
fix: prevent command injection via working_dir parameter in sidecar

### DIFF
--- a/docker/sidecar/main.py
+++ b/docker/sidecar/main.py
@@ -10,6 +10,7 @@ Requires: shareProcessNamespace: true in the pod spec.
 
 import asyncio
 import os
+import shlex
 import time
 import traceback
 from contextlib import asynccontextmanager
@@ -137,9 +138,11 @@ def get_language_command(language: str, code: str, working_dir: str) -> tuple[li
     """
     # Helper to wrap command with cd to working directory
     def wrap_cmd(cmd: str, env_setup: str = "") -> list[str]:
+        # Sanitize working_dir to prevent command injection
+        safe_working_dir = shlex.quote(working_dir)
         if env_setup:
-            return ["sh", "-c", f"{env_setup} cd {working_dir} && {cmd}"]
-        return ["sh", "-c", f"cd {working_dir} && {cmd}"]
+            return ["sh", "-c", f"{env_setup} cd {safe_working_dir} && {cmd}"]
+        return ["sh", "-c", f"cd {safe_working_dir} && {cmd}"]
 
     # Environment setup strings for each language runtime
     # These match the ENTRYPOINT environment in each language's Dockerfile


### PR DESCRIPTION
## Summary
- Apply `shlex.quote()` to sanitize the `working_dir` parameter before shell command interpolation in `wrap_cmd()`
- Prevents command injection attacks via shell metacharacters (e.g., `/tmp; id #`)
- Defense-in-depth fix for the sidecar HTTP API

## Context
The `wrap_cmd` function in `docker/sidecar/main.py` directly interpolated `working_dir` into shell commands without sanitization. While the external API currently hardcodes this value to `/mnt/data`, the sidecar's internal HTTP API (port 8080) was exploitable by:
- Pod-to-pod attacks within the cluster
- SSRF from other services
- Future API changes that might expose the parameter

Fixes wipash/K8sInterpreter#1

## Test plan
- [x] Linting passes (`just lint`)
- [x] Format check passes (`just format-check`)
- [x] Unit tests pass (87/87)
- [ ] Rebuild sidecar Docker image and deploy to test cluster
- [ ] Verify normal code execution still works
- [ ] Verify malicious `working_dir` values result in "directory not found" errors