### PR TITLE
fix: sanitize uploaded filenames before storage to match LibreChat

### DIFF
--- a/src/api/files.py
+++ b/src/api/files.py
@@ -111,16 +111,17 @@ async def upload_file(
             # Read file content
             content = await file.read()
 
-            # Store file directly
+            # Sanitize filename before storage so the name on disk in the
+            # execution pod matches what LibreChat reports to the model.
+            sanitized_name = OutputProcessor.sanitize_filename(file.filename)
+
+            # Store file with the sanitized name
             file_id = await file_service.store_uploaded_file(
                 session_id=session_id,
-                filename=file.filename,
+                filename=sanitized_name,
                 content=content,
                 content_type=file.content_type,
             )
-
-            # Sanitize filename to match what will be used in container
-            sanitized_name = OutputProcessor.sanitize_filename(file.filename)
 
             uploaded_files.append(
                 {


### PR DESCRIPTION
## Summary

When files are uploaded via LibreChat, LibreChat sanitizes filenames (replacing spaces and special characters with underscores) before telling the model about them. However, KCR was storing files with the original unsanitized filename. This meant the model would try to open `my_file.csv` but the file on disk in the pod was actually `my file.csv`, causing the first execution to fail. The model would then have to list the directory, discover the real name, and retry.

This fix moves filename sanitization to happen **before** storage, so the name on disk matches what LibreChat reports. The original filename is still preserved in the upload response's `metadata.original-filename` field.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added parametrized unit tests covering filenames with spaces, parentheses, `&`, `#`, `!@#$`, and unicode characters
- [x] All 33 unit tests pass locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules