### PR TITLE
fix: increase uvicorn keep-alive timeout to prevent socket hang-ups

### DIFF
--- a/helm-deployments/kubecoderun/templates/configmap.yaml
+++ b/helm-deployments/kubecoderun/templates/configmap.yaml
@@ -19,6 +19,7 @@ data:
   {{- if .Values.api.cors.origins }}
   CORS_ORIGINS: {{ .Values.api.cors.origins | toJson | quote }}
   {{- end }}
+  API_TIMEOUT_KEEP_ALIVE: {{ .Values.api.timeoutKeepAlive | quote }}
   HEALTH_CHECK_INTERVAL: {{ .Values.api.healthCheck.interval | quote }}
   HEALTH_CHECK_TIMEOUT: {{ .Values.api.healthCheck.timeout | quote }}
 

--- a/helm-deployments/kubecoderun/values.yaml
+++ b/helm-deployments/kubecoderun/values.yaml
@@ -149,6 +149,11 @@ api:
     enabled: false
     origins: []
 
+  # Keep-alive timeout (seconds) for idle HTTP connections.
+  # Must exceed the client's keep-alive timeout to prevent socket hang-ups
+  # on long-running requests (e.g. job-executor cold starts).
+  timeoutKeepAlive: 75
+
   # Health checks
   healthCheck:
     interval: 30

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -65,6 +65,7 @@ class Settings(BaseSettings):
     api_port: int = Field(default=8000, ge=1, le=65535)
     api_debug: bool = Field(default=False)
     api_reload: bool = Field(default=False)
+    api_timeout_keep_alive: int = Field(default=75, ge=5, le=600)
 
     # SSL/HTTPS Configuration
     enable_https: bool = Field(default=False)
@@ -455,6 +456,7 @@ class Settings(BaseSettings):
             api_port=self.api_port,
             api_debug=self.api_debug,
             api_reload=self.api_reload,
+            api_timeout_keep_alive=self.api_timeout_keep_alive,
             enable_https=self.enable_https,
             https_port=self.https_port,
             ssl_cert_file=self.ssl_cert_file,

--- a/src/config/api.py
+++ b/src/config/api.py
@@ -18,6 +18,16 @@ class APIConfig(BaseSettings):
     debug: bool = Field(default=False, alias="api_debug")
     reload: bool = Field(default=False, alias="api_reload")
 
+    # Server tuning
+    timeout_keep_alive: int = Field(
+        default=75,
+        ge=5,
+        le=600,
+        alias="api_timeout_keep_alive",
+        description="Seconds to keep idle HTTP connections open (uvicorn --timeout-keep-alive). "
+        "Must be higher than the client's keep-alive timeout to avoid socket hang-up race conditions.",
+    )
+
     # SSL/HTTPS Configuration
     enable_https: bool = Field(default=False)
     https_port: int = Field(default=443, ge=1, le=65535)

--- a/src/main.py
+++ b/src/main.py
@@ -367,6 +367,7 @@ def run_server():
             port=settings.https_port,
             reload=settings.api_reload,
             log_level=settings.log_level.lower(),
+            timeout_keep_alive=settings.api_timeout_keep_alive,
             **ssl_config,
         )
     else:
@@ -377,6 +378,7 @@ def run_server():
             port=settings.api_port,
             reload=settings.api_reload,
             log_level=settings.log_level.lower(),
+            timeout_keep_alive=settings.api_timeout_keep_alive,
         )
 
 


### PR DESCRIPTION
## Summary

Uvicorn's default `timeout-keep-alive` of 5 seconds causes a race condition when HTTP clients (e.g. LibreChat) reuse keep-alive connections for long-running job-executor requests. The server closes idle connections before the client sends the next request, resulting in `socket hang up` errors on the client side.

This adds a configurable `API_TIMEOUT_KEEP_ALIVE` setting (default: 75s, matching the nginx convention) wired through config, uvicorn, and the helm chart. Pool-based executions (~100ms) were unaffected because they complete before any timeout fires; job executions (10-30s+ for Go/Rust/Java cold starts) consistently triggered the issue.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `just lint` — all checks passed
- [x] `just test-unit` — 1301 tests passed
- [ ] Deploy to cluster and verify Go code execution completes without socket hang-up
- [ ] Verify `API_TIMEOUT_KEEP_ALIVE` env var override works

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules