### PR TITLE
fix: capture generated files for job execution path

### DIFF
--- a/src/services/execution/runner.py
+++ b/src/services/execution/runner.py
@@ -21,7 +21,7 @@ from ...models import (
     OutputType,
 )
 from ...utils.id_generator import generate_execution_id
-from ..kubernetes import ExecutionResult, KubernetesManager, PodHandle
+from ..kubernetes import ExecutionResult, JobHandle, KubernetesManager, PodHandle
 from ..metrics import ExecutionMetrics, metrics_collector
 from .output import OutputProcessor
 
@@ -180,15 +180,21 @@ class CodeExecutionRunner:
             # Process outputs
             outputs = self._process_outputs(result.stdout, result.stderr, end_time)
 
-            # For pod-based execution, check for generated files
+            # Check for generated files
             generated_files = []
             if handle:
-                # Only detect files if code likely generates files
-                should_detect_files = files or any(
-                    kw in request.code for kw in ["open(", "savefig", "to_csv", "write(", ".save("]
-                )
-                if should_detect_files:
+                if container_source == "job":
+                    # Always detect files for jobs — keyword heuristic is
+                    # Python-centric and the HTTP call cost is negligible
+                    # vs job cold-start time
                     generated_files = await self._detect_generated_files(handle)
+                else:
+                    # Only detect files if code likely generates files
+                    should_detect_files = files or any(
+                        kw in request.code for kw in ["open(", "savefig", "to_csv", "write(", ".save("]
+                    )
+                    if should_detect_files:
+                        generated_files = await self._detect_generated_files(handle)
 
             mounted_filenames = self._get_mounted_filenames(files)
             filtered_files = self._filter_generated_files(generated_files, mounted_filenames)
@@ -332,7 +338,7 @@ class CodeExecutionRunner:
         except Exception as e:
             logger.error("Failed to record execution metrics", error=str(e))
 
-    async def _detect_generated_files(self, handle: PodHandle) -> list[dict[str, Any]]:
+    async def _detect_generated_files(self, handle: PodHandle | JobHandle) -> list[dict[str, Any]]:
         """Detect files generated during execution via sidecar HTTP API."""
         if not handle or not handle.pod_ip:
             return []

--- a/src/services/kubernetes/__init__.py
+++ b/src/services/kubernetes/__init__.py
@@ -5,9 +5,10 @@ This module provides Kubernetes-native pod and job execution.
 
 from .client import get_kubernetes_client
 from .manager import KubernetesManager
-from .models import ExecutionResult, PodHandle, PodStatus
+from .models import ExecutionResult, JobHandle, PodHandle, PodStatus
 
 __all__ = [
+    "JobHandle",
     "PodHandle",
     "ExecutionResult",
     "PodStatus",

--- a/src/services/kubernetes/manager.py
+++ b/src/services/kubernetes/manager.py
@@ -20,6 +20,7 @@ from .job_executor import JobExecutor
 from .models import (
     ExecutionResult,
     FileData,
+    JobHandle,
     PodHandle,
     PodSpec,
     PoolConfig,
@@ -97,7 +98,7 @@ class KubernetesManager:
         }
 
         # Track active executions
-        self._active_handles: dict[str, PodHandle] = {}  # session_id -> handle
+        self._active_handles: dict[str, PodHandle | JobHandle] = {}  # session_id -> handle
 
         self._started = False
 
@@ -282,7 +283,7 @@ class KubernetesManager:
                 network_isolated=self.network_isolated,
             )
 
-            result = await self._job_executor.execute_with_job(
+            result, job_handle = await self._job_executor.execute_with_job(
                 spec,
                 session_id,
                 code,
@@ -291,13 +292,13 @@ class KubernetesManager:
                 initial_state=initial_state,
                 capture_state=capture_state,
             )
-            return result, None, "job"
+            return result, job_handle, "job"
 
-    async def destroy_pod(self, handle: PodHandle):
-        """Destroy an execution pod.
+    async def destroy_pod(self, handle: PodHandle | JobHandle):
+        """Destroy an execution pod or job.
 
         Args:
-            handle: Pod handle to destroy
+            handle: Pod or job handle to destroy
         """
         if not handle:
             return
@@ -306,12 +307,15 @@ class KubernetesManager:
         if handle.session_id and handle.session_id in self._active_handles:
             del self._active_handles[handle.session_id]
 
-        # Release from pool (with destroy=True)
-        await self._pool_manager.release(handle, destroy=True)
+        if isinstance(handle, JobHandle):
+            await self._job_executor.delete_job(handle)
+        else:
+            # Release from pool (with destroy=True)
+            await self._pool_manager.release(handle, destroy=True)
 
     async def copy_files_to_pod(
         self,
-        handle: PodHandle,
+        handle: PodHandle | JobHandle,
         files: list[FileData],
     ) -> bool:
         """Copy files to a pod.
@@ -348,7 +352,7 @@ class KubernetesManager:
 
     async def copy_file_from_pod(
         self,
-        handle: PodHandle,
+        handle: PodHandle | JobHandle,
         path: str,
     ) -> bytes | None:
         """Copy a file from a pod.
@@ -388,7 +392,7 @@ class KubernetesManager:
 
     async def destroy_pods_batch(
         self,
-        handles: list[PodHandle],
+        handles: list[PodHandle | JobHandle],
     ) -> int:
         """Destroy multiple pods.
 


### PR DESCRIPTION
## Summary

Files generated during code execution (plots, CSVs, etc.) were only captured for pool-based execution (Python/JS). The job execution path (Go, Rust, Java, C, etc.) silently dropped all generated files because `execute_with_job` returned `None` as the handle and auto-deleted the job pod before file detection could run.

This fix returns the `JobHandle` from job execution so the existing file detection and download pipeline works unchanged for cold-path languages and pool-fallback scenarios.

Fixes #17

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `just test-unit` — 1327 passed (includes 7 new/updated tests)
- [x] `just lint` — all checks passed
- [x] `just format-check` — all formatted
- [x] `just typecheck` — all checks passed

New tests added:
- `test_execute_with_job_success` — verifies `(result, handle)` tuple return, no auto-delete
- `test_execute_with_job_pod_not_ready` — verifies handle returned for caller cleanup
- `test_execute_with_job_cleanup_on_error` — verifies `delete_job` called on exception
- `test_execute_with_job_returns_handle_with_pod_ip` — verifies handle has `pod_ip` and `sidecar_url`
- `test_destroy_pod_with_job_handle` — verifies `isinstance` dispatch calls `delete_job`
- `test_file_detection_runs_for_job_source` — verifies detection runs without keyword heuristic
- `test_keyword_heuristic_skipped_for_jobs` — verifies heuristic bypass for jobs
- `test_keyword_heuristic_still_applies_for_pool` — verifies no regression for pool path

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules