### PR TITLE
fix: make gmsh a best-effort install for ARM compatibility

### DIFF
--- a/docker/python.Dockerfile
+++ b/docker/python.Dockerfile
@@ -71,6 +71,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
      -r /tmp/python-documents.txt \
      -r /tmp/python-utilities.txt
 
+# Install packages that may not have wheels for all architectures (e.g. ARM)
+# These are best-effort: the build succeeds even if they're unavailable
+COPY requirements/python-optional.txt /tmp/python-optional.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+     pip install -r /tmp/python-optional.txt || true
+
 ################################
 # Runtime dependencies stage - install runtime libraries
 ################################

--- a/docker/requirements/python-analysis.txt
+++ b/docker/requirements/python-analysis.txt
@@ -17,6 +17,5 @@ patsy>=0.5
 kiwisolver>=1.4
 joblib>=1.3
 threadpoolctl>=3.2
-gmsh>=4.15.1
 fortranformat>=2.0.3
 ezdxf>=1.4.3

--- a/docker/requirements/python-optional.txt
+++ b/docker/requirements/python-optional.txt
@@ -1,0 +1,4 @@
+# Packages that may not have wheels for all architectures (e.g. ARM).
+# Installed as best-effort — build continues if these fail.
+
+gmsh>=4.15.1


### PR DESCRIPTION
- Move gmsh from python-analysis.txt to a new python-optional.txt requirements file
- Install optional packages with || true so the Docker build succeeds even when wheels aren't available for the target architecture (e.g. ARM)